### PR TITLE
feat: automated tox testing & typed default params

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with Tox
+        run: tox

--- a/epoch_cheats/PARAMS.py
+++ b/epoch_cheats/PARAMS.py
@@ -1,13 +1,31 @@
 """Constant Parameters."""
-type_params = dict[str, dict[str, float | int] | list[str]]
-default_params: type_params = {
-    "constant": {
-        "qe": 1.60217663e-19,
-        "mu0": 1.25663706212e-6,
-        "kb": 1.380649e-23,
-        "pi": 3.141592653589793,
+from typing import NamedTuple
+
+from sympy import Symbol
+
+
+class Params(NamedTuple):
+    """NamedTuple of constants and unparseable lines.
+
+    - Used by load_params() to check .PARAMS.params for valid values
+
+    Attributes:
+        constant (dict[Symbol, float]): dictionary of constant values
+        unparseable (list[str]): list of lines that could not be parsed
+    """
+
+    constant: dict[Symbol, float]
+    unparseables: list[str]
+
+
+default_params = Params(
+    constant={
+        Symbol("qe"): 1.60217663e-19,
+        Symbol("mu0"): 1.25663706212e-6,
+        Symbol("kb"): 1.380649e-23,
+        Symbol("pi"): 3.141592653589793,
     },
-    "unparseable": [
+    unparseables=[
         "always",
         "never",
         "species",
@@ -18,4 +36,4 @@ default_params: type_params = {
         "T",
         ",",
     ],
-}
+)

--- a/epoch_cheats/deck_parse.py
+++ b/epoch_cheats/deck_parse.py
@@ -18,30 +18,16 @@ that use Sympy symbols.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, NamedTuple, Union, cast
+from typing import Union
 
 from sympy import Expr, Symbol
 from sympy.abc import _clash
 from sympy.parsing.sympy_parser import parse_expr
 
-from .PARAMS import default_params
+from .PARAMS import Params, default_params
 
 
-class Params(NamedTuple):
-    """NamedTuple of constants and unparseable lines.
-
-    - Used by load_params() to check .PARAMS.params for valid values
-
-    Attributes:
-        constant (dict[Symbol, float]): dictionary of constant values
-        unparseable (list[str]): list of lines that could not be parsed
-    """
-
-    constant: dict[Symbol, float]
-    unparseables: list[str]
-
-
-def load_params(param_dict: dict[str, Any] = default_params) -> Params:
+def load_params(param_dict: Params = default_params) -> Params:
     """Load constants, by default from .PARAMS.params.
 
     Args:
@@ -50,9 +36,8 @@ def load_params(param_dict: dict[str, Any] = default_params) -> Params:
     Returns:
         Params: NamedTuple of constants and unparseable
     """
-    param_dict = dict(param_dict)
-    constant = {Symbol(k): float(v) for k, v in param_dict["constant"].items()}
-    unparsables: list[str] = cast(list[str], default_params["unparseable"])
+    constant = dict(param_dict.constant)
+    unparsables: list[str] = list(param_dict.unparseables)
     return Params(constant, unparsables)
 
 

--- a/tests/test_deck_parse.py
+++ b/tests/test_deck_parse.py
@@ -115,14 +115,14 @@ def test_parse_constant_block_chained():
 
 
 def test_get_deck_constants_sym(deck_file):
-    expected = {
+    expected_data = {
         "qe": 1.60217663e-19,
         "mu0": 1.25663706212e-06,
         "kb": 1.380649e-23,
         "pi": 3.14,
         "g": 9.81,
     }
-    expected = {Symbol(k): v for k, v in expected.items()}
+    expected = {Symbol(k): v for k, v in expected_data.items()}
     assert get_deck_constants_sym(deck_file) == expected
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,12 @@
 [tox]
-minversion = 3.8.0
-envlist = py38, py39, py310, flake8, mypy
+minversion = 3.9.0
+envlist = py39, py310, flake8, mypy
 isolated_build = true
+
+[gh-actions]
+python = 
+    3.9: py39
+    3.10: py310, flake8, mypy
 
 [testenv]
 setenv = 
@@ -23,6 +28,6 @@ commands =
 basepython = python3.10
 deps =
     -r{toxinidir}/requirements.txt
-    -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
-    mypy . --exclude=tests
+    mypy . --exclude=build


### PR DESCRIPTION
- Added testing with Tox to confirm working on python 3.9 and 3.10 (pytest) as well as confirm code passes mypy and flake8
- Moved Params class definition to PARAMS and use it when defining default_params to force typing